### PR TITLE
Fix duplicate label in signup form

### DIFF
--- a/_site/signup/index.html
+++ b/_site/signup/index.html
@@ -53,7 +53,6 @@
     <input type="checkbox" id="new-player" name="New Player" style="margin-bottom: 1rem;">
     I’m a new player \/ I do not have a Fargo account OR an APA account.
   </label>
-  </label>
 
   <label for="fargo-screenshot">Fargo Rating Screenshot (if you have one):</label>
   <input type="file" id="fargo-screenshot" name="Fargo Screenshot" accept="image/*" style="margin-bottom: 1rem;">

--- a/signup.html
+++ b/signup.html
@@ -27,7 +27,6 @@ title: Sign Up
     <input type="checkbox" id="new-player" name="New Player" style="margin-bottom: 1rem;">
     I’m a new player \/ I do not have a Fargo account OR an APA account.
   </label>
-  </label>
 
   <label for="fargo-screenshot">Fargo Rating Screenshot (if you have one):</label>
   <input type="file" id="fargo-screenshot" name="Fargo Screenshot" accept="image/*" style="margin-bottom: 1rem;">


### PR DESCRIPTION
## Summary
- remove stray closing tag in `signup.html`

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6840e2e57f9c8327a7c5d47e740d87a4